### PR TITLE
lambdaを分割する

### DIFF
--- a/SlackManager.py
+++ b/SlackManager.py
@@ -37,52 +37,19 @@ class SlackManager:
 		response = requests.post(method_url, payload)
 		return response
 
-	def post_block_message(self, channel_name, message, user_icon_url, thread_ts=None):
+	def post_block_message(self, channel_name, message, user_icon_url):
 		method_url = "https://slack.com/api/chat.postMessage"
 
-		# thread_tsがあったらsectionはなし
-		block = ""
-		if not thread_ts:
-			block = block + """[
+		block = """[
 							{
 									"type": "section",
 									"text": {
 											"type": "mrkdwn","""
-			block = block + '"text": "*#{0}*"'.format(channel_name)
-			block = block + """
-									}
-							},
-							{
-									"type": "divider"
-							},
-							{
-									"type": "context",
-									"elements": [
-											{
-											"type": "image","""
-			block = block + '"image_url": "{0}",'.format(user_icon_url)
-			block = block + """"alt_text": "images"
-									}
-							]
-					}
-			]"""
-
-		else:
-			block = block + """[
-							{
-									"type": "divider"
-							},
-							{
-									"type": "context",
-									"elements": [
-											{
-											"type": "image","""
-			block = block + '"image_url": "{0}",'.format(user_icon_url)
-			block = block + """"alt_text": "images"
-									}
-							]
-					}
-			]"""
+		block = block +  '"text": "*#{0}*"'.format(channel_name)
+		block = block + """
+								}
+						}]
+		"""
 
 		payload = {
 			"channel": self.channel,
@@ -92,9 +59,6 @@ class SlackManager:
 			"unfurl_media": "true",
 			"blocks": block
 		}
-
-		if thread_ts:
-			payload['thread_ts'] = thread_ts
 
 		response = requests.post(method_url, payload)
 		return response

--- a/SlackManager.py
+++ b/SlackManager.py
@@ -6,7 +6,14 @@ class SlackManager:
 		self.oauth_token = oauth_token
 		self.channel = channel
 
-	def post_message_slack(self, message, thread_ts=None):
+	def post_message_slack(self, message, username=None, icon_url=None, thread_ts=None):
+		"""
+		Args:
+			message,
+			username,
+			icon_url,
+			thread_ts
+		"""
 		method_url = "https://slack.com/api/chat.postMessage"
 
 		payload = {
@@ -17,8 +24,15 @@ class SlackManager:
 			"unfurl_media": True
 		}
 
+		if username and icon_url:
+			payload['as_user'] = False
+			payload['icon_url'] = icon_url
+			payload['username'] = username
+
 		if thread_ts:
 			payload['thread_ts'] = thread_ts
+
+		print('post_message_slack: ', payload)
 
 		response = requests.post(method_url, payload)
 		return response

--- a/handler.py
+++ b/handler.py
@@ -71,14 +71,15 @@ def main(event, context):
         if ts != "":
             res = slack_manager.post_block_message(channel_name, event_message, user_icon_url, ts)
             print(res.text)
-            res = slack_manager.post_message_slack(event_message,ts)
+            res = slack_manager.post_message_slack(event_message, profile_display_name, user_icon_url, ts)
             print(res.text)
         # 初めてではなければ、リプライにする
         else:
             res = slack_manager.post_block_message(channel_name, event_message, user_icon_url)
             print(res.text)
             res_dict = json.loads(res.text)
-            res = slack_manager.post_message_slack(event_message, res_dict["ts"])
+            print(res_dict['ts'])
+            res = slack_manager.post_message_slack(event_message, profile_display_name, user_icon_url, res_dict["ts"])
             print(res.text)
 
         return {

--- a/handler.py
+++ b/handler.py
@@ -1,12 +1,12 @@
 import json
 import os
+import codecs
 import pprint
 import datetime as dt
 from SlackManager import *
 import Common
 
 def main(event, context):
-    # tokenのチェックをする
 
     token = os.environ['SLACK_TOKEN']
     oauth_token = os.environ['SLACK_OAUTH_TOKEN']
@@ -19,7 +19,7 @@ def main(event, context):
     )
 
     try: 
-        body = json.loads(event['body'])
+        body = event
         print("event")
         print(body)
 
@@ -34,7 +34,13 @@ def main(event, context):
             event_message = body['event']['text']
         else:
             event_message = "null"
+        if "subtype" in body['event'].keys():
+            print("subtype: ", body['event']['subtype'])
+
+        print(type(event_message))
         print("event_message: ", event_message)
+        # event_message = event_message.encode().decode('unicode-escape')
+        # print("event_message: ", event_message)
             
         # チャンネル名を取得
         channel_info = slack_manager.get_channel_info(event_channel_id)
@@ -68,18 +74,16 @@ def main(event, context):
         ts = slack_manager.is_posted_channel(json.loads(res.text), channel_name)
 
         # もし初めてのイベントなら#{チャンネル名}を最初に投稿する
-        if ts != "":
-            res = slack_manager.post_block_message(channel_name, event_message, user_icon_url, ts)
+        if ts == "":
+            res = slack_manager.post_block_message(channel_name, event_message, user_icon_url)
             print(res.text)
+            res_dict = json.loads(res.text)
+            ts = res_dict['ts']
             res = slack_manager.post_message_slack(event_message, profile_display_name, user_icon_url, ts)
             print(res.text)
         # 初めてではなければ、リプライにする
         else:
-            res = slack_manager.post_block_message(channel_name, event_message, user_icon_url)
-            print(res.text)
-            res_dict = json.loads(res.text)
-            print(res_dict['ts'])
-            res = slack_manager.post_message_slack(event_message, profile_display_name, user_icon_url, res_dict["ts"])
+            res = slack_manager.post_message_slack(event_message, profile_display_name, user_icon_url, ts)
             print(res.text)
 
         return {
@@ -97,21 +101,3 @@ def main(event, context):
             'body': "ok",
             'isBase64Encoded': False
         }
-
-# url登録時のバリデーション用
-def validation(event):
-
-    request_body = json.loadcs(event['body'])
-    # challenge = body["challenge"]
-    # print(challenge)
-
-    body = {
-        "challenge": request_body['challenge'],
-    }
-
-    response = {
-        "statusCode": 200,
-        "body": json.dumps(body)
-    }
-
-    return response

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,18 +1,52 @@
 service: all-times
 
+frameworkVersion: '>=1.0.0 <2.0.0'
+
 provider:
   name: aws
   runtime: python3.7
   region: ap-northeast-1
-  stage: prod  
+  stage: ${opt:stage, 'stg'}
+
+package:
+  individually: true
+  exclude:
+    - slack_secrets.yml
+    - response_template.json
+    - README.md
 
 functions:
-  main:
-    handler: handler.main
+  slackRequestHandler:
+    handler: slackRequestHandler.main
     environment:
-      SLACK_TOKEN: ${file(./slack_secrets.yml):token}
-      SLACK_CHANNEL_ID: ${file(./slack_secrets.yml):channel_id}
-      SLACK_OAUTH_TOKEN: ${file(./slack_secrets.yml):oauth_token}
+      SLACK_VERIFICATION_TOKEN: ${file(./slack_secrets.yml):verification_token}
+      SLACK_APP_ID: ${file(./slack_secrets.yml):app_id}
+      MAIN_FUNCTION_ARN:         
+        Fn::Join:
+        - ':'
+        - - 'arn:aws:lambda'
+          - Ref: 'AWS::Region'
+          - Ref: 'AWS::AccountId'
+          - 'function'
+          - 'all-times-${self:provider.stage}-main'
+    package:
+      exclude:
+        - handler.py
+        - Common.py
+        - SlackManager.py
+        - bin/**
+        - bin*/**
+        - certifi/**
+        - certifi*/**
+        - chardet/**
+        - chardet*/**
+        - idna/**
+        - idna*/**
+        - requests/**
+        - requests*/**
+        - urllib3/**
+        - urllib3*/**
+    role: myCustRole1
     events:
       - http:
           path: /
@@ -22,9 +56,90 @@ functions:
             headers:
               Content-Type: "'application/json'"
             template: ${file(./response_template.json)}
-    timeout: 30
+  main:
+    handler: handler.main
+    environment:
+      SLACK_TOKEN: ${file(./slack_secrets.yml):token}
+      SLACK_CHANNEL_ID: ${file(./slack_secrets.yml):channel_id}
+      SLACK_OAUTH_TOKEN: ${file(./slack_secrets.yml):oauth_token}
+    timeout: 60
+    role: myCustRole2
+    package:
+      exclude:
+        - slackRequestHandler.py
 
-package:
-  exclude:
-    - slack_secrets.yml
-    - response_template.json
+resources:
+  Resources:
+    myCustRole1:
+      Type: AWS::IAM::Role
+      Properties:
+        Path: /my/cust/path/
+        RoleName: MyCustRole1
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - lambda.amazonaws.com
+              Action: sts:AssumeRole
+        Policies:
+          - PolicyName: myPolicyName
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow # note that these rights are given in the default policy and are required if you want logs out of your lambda(s)
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource:
+                    - 'Fn::Join':
+                      - ':'
+                      -
+                        - 'arn:aws:logs'
+                        - Ref: 'AWS::Region'
+                        - Ref: 'AWS::AccountId'
+                        - 'log-group:/aws/lambda/*:*:*'
+                - Effect: 'Allow'
+                  Action:
+                    - 'lambda:InvokeFunction'
+                  Resource:
+                    Fn::Join:
+                      - ':'
+                      - - 'arn:aws:lambda'
+                        - Ref: 'AWS::Region'
+                        - Ref: 'AWS::AccountId'
+                        - 'function'
+                        - 'all-times-${self:provider.stage}-main'
+    myCustRole2:
+      Type: AWS::IAM::Role
+      Properties:
+        Path: /my/cust/path/
+        RoleName: MyCustRole2
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - lambda.amazonaws.com
+              Action: sts:AssumeRole
+        Policies:
+          - PolicyName: myPolicyName
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow # note that these rights are given in the default policy and are required if you want logs out of your lambda(s)
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource:
+                    - 'Fn::Join':
+                      - ':'
+                      -
+                        - 'arn:aws:logs'
+                        - Ref: 'AWS::Region'
+                        - Ref: 'AWS::AccountId'
+                        - 'log-group:/aws/lambda/*:*:*'

--- a/slackRequestHandler.py
+++ b/slackRequestHandler.py
@@ -1,0 +1,55 @@
+import boto3
+import os
+import json
+
+def main(event, context):
+  body = json.loads(event['body'])
+  print(body)
+
+  # 初回のAPIエンドポイント検証
+  if body['type'] == "url_verification":
+    response_body = {
+        "challenge": body['challenge'],
+    }
+
+    return {
+      'statusCode': 200,
+      'body': json.dumps(response_body),
+      'isBase64Encoded': False
+    }
+
+  verification_token = os.environ['SLACK_VERIFICATION_TOKEN']
+  app_id = os.environ['SLACK_APP_ID']
+
+  # リクエストが正当かチェック
+  if body['token'] != verification_token or body['api_app_id'] != app_id:
+    return None
+
+  if 'body' in event.keys():
+    try:
+      client = boto3.client('lambda')
+      function_arn = os.environ['MAIN_FUNCTION_ARN']
+
+      body = event['body']
+      # payload = body.encode("unicode-escape")
+      payload = body.encode()
+      print("payload")
+      print(payload)
+      
+
+      response = client.invoke(
+        FunctionName = function_arn,
+        InvocationType = 'Event',
+        Payload = payload
+      )
+      print(response)
+    except:
+      import traceback
+      print("[Error]")
+      traceback.print_exc()
+
+  return {
+    'statusCode': 200,
+    'body': "ok",
+    'isBase64Encoded': False
+  }

--- a/slack_secrets.sample
+++ b/slack_secrets.sample
@@ -1,0 +1,5 @@
+token: ***
+channel_id: ***
+oauth_token: ***
+verification_token: ***
+app_id: ***


### PR DESCRIPTION
## 内容
いまは1つのlambdaで
- リクエストを受けとってSlackにレスポンスを返す 
- リクエストのボディを読んでチャンネルに投稿する

を行っているが、これを2つに分ける。

リクエストを受け取ってから3秒以内にレスポンスを返さないとSlackがリクエストの送信をリトライしてしまう。
リトライを防ぐため、トークン・アプリIDの検証をしてすぐに200レスポンスを返すようにし、チャンネルで発生したイベントに応じた処理は別のlambdaで行うようにする。
